### PR TITLE
Do not push rendered html to js client, use json instead.

### DIFF
--- a/app/javascript/packs/conversation.js
+++ b/app/javascript/packs/conversation.js
@@ -29,9 +29,30 @@ class Conversation {
 
 	received(data) {
 		log('received message');
-		this._view.append(data.message);
+    this.appendMessage(data.message);
 		this.scrollBottom();
 	}
+
+  appendMessage(message) {
+    var appended = "";
+    if (message.user_id === config.currentUserId ) {
+      appended += '<div class="message message-self">';
+    } else {
+      appended += '<div class="message message-friend">';
+    }
+    appended += '\
+      <div class="message-user">\
+        <span class="realtime-status"></span>\
+        <span class="username">'+message.username+'</span>\
+        <time class="time">'+message.created_at + '</time>\
+      </div>\
+        <div class="message-bubble">\
+          <div class="message-content">'+message.body +'</div>\
+        </div>\
+    </div>\
+    ';
+    this._view.append(appended);
+  }
 
 	getChannel(channel, cid) {
 		let self = this;
@@ -53,7 +74,6 @@ class Conversation {
 					.addClass('self-offline');
 			},
 			received(data) {
-				// Hey, @yiliang, why this hook func never called ?
 				if (data.message) {
 					self.received({
 						channel,

--- a/app/jobs/message_broadcast_job.rb
+++ b/app/jobs/message_broadcast_job.rb
@@ -3,14 +3,15 @@ class MessageBroadcastJob < ApplicationJob
 
   def perform(message)
     ActionCable.server.broadcast "messages_#{message.conversation.id}",
-      message: render_message(message), from: message.user_id
+      message: { user_id: message.user_id, username: message.user.username, body: message.body,
+                 created_at: message.friendly_create_at }
   end
-
-  private
-    def render_message(message)
-      ApplicationController.renderer.render(
-        partial: 'messages/message',
-        locals: { message: message, current_user: message.user }
-      )
-    end
+  #
+  # private
+  #   def render_message(message)
+  #     ApplicationController.renderer.render(
+  #       partial: 'messages/message',
+  #       locals: { message: message, current_user: message.user}
+  #     )
+  #   end
 end

--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -3,6 +3,7 @@
     this._global || (this._global = {});
     this._global.channel = 'MessagesChannel';
     this._global.conversationId = '<%= @conversation.id %>';
+    this._global.currentUserId = '<%= current_user.id %>';
 }).call(this);
 </script>
 


### PR DESCRIPTION
If push rendered html to js client, server side don't know the current_user because the rendering happens in a job.  Previously, I filled current_user by message.user which is totally incorrect.

On the other hand, basically there is no way for client js to retrieve session[:user_id] unless using another gem. So I explicitly put the current_user.id in conversation's show template. Then we can use this currentUserId to compare with user_id from pushed message.